### PR TITLE
Fix inline images from quoted emails causing invalid base64 GraphQL error

### DIFF
--- a/app/frontend/shared/components/Form/fields/FieldEditor/features/image-handler/ImageHandler.vue
+++ b/app/frontend/shared/components/Form/fields/FieldEditor/features/image-handler/ImageHandler.vue
@@ -27,7 +27,7 @@ const isResizing = ref(false)
 const imageLoaded = ref(false)
 const failedDueToCors = ref(false)
 const isDraggable = computed(() => props.node.attrs.isDraggable)
-const uploadCacheExists = computed(() => props.node.attrs.src.startsWith('/api/v1/attachments/'))
+const uploadCacheExists = computed(() => props.node.attrs.src.startsWith('/api/v1/'))
 const uploadInsideOtherEditor = computed(
   () => props.node.attrs.src.startsWith('blob:') && !props.node.attrs.content,
 )
@@ -42,7 +42,7 @@ const getNodeStyle = () =>
   }, {})
 
 const handleUpload = () => {
-  if (props.node.attrs.src.startsWith('/api/v1/attachments/')) return
+  if (props.node.attrs.src.startsWith('/api/v1/')) return
   if (props.node.attrs.src.startsWith('blob:') && !props.node.attrs.content) return
 
   if (props.node.attrs.src.startsWith('file:')) {


### PR DESCRIPTION
## Summary

- Fixes a transient red error flash (`Variable $files of type [UploadFileInput!]! was provided invalid value for 0.content (invalid base64)`) when replying to or forwarding an email with inline images (embedded screenshots, logos, etc.)
- This is an **upstream Zammad bug** — no KC code is involved

## Root Cause

When an email with inline images is quoted in a reply/forward, the backend replaces `cid:` references with `/api/v1/ticket_attachment/:ticket_id/:article_id/:id?view=inline` URLs. The `ImageHandler.vue` component's `handleUpload()` guard only matched `/api/v1/attachments/`, so `ticket_attachment` URLs fell through to the else branch which sent the raw URL path as base64 `content` to the GraphQL mutation. `BinaryStringType` then failed on `Base64.strict_decode64`.

## Fix

Broaden the guard from `/api/v1/attachments/` to `/api/v1/` — any image served by the Zammad API is already persisted and doesn't need re-uploading. Verified via audit that no `/api/v1/` URL could legitimately need client-side uploading.

## Test plan

- [ ] Reply to an email ticket that has inline images (embedded screenshots) — no red error flash
- [ ] Forward an email ticket with inline images — no red error flash
- [ ] Upload a new image via the editor toolbar button — still works normally
- [ ] Paste an external image URL into the editor — still uploads correctly
- [ ] Shared draft with inline images — still renders correctly
- [ ] Verify inline images in quoted content display at full opacity (not dimmed)

## Upstream submission

This commit can be cherry-picked cleanly onto upstream `zammad/zammad` `develop` — it touches only one file with no KC dependencies.